### PR TITLE
JSON.QuerySingle - Result data to dynamic

### DIFF
--- a/Frends.JSON.QuerySingle/CHANGELOG.md
+++ b/Frends.JSON.QuerySingle/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.2.0] - 2024-11-07
+### Fixed
+- Fixed issue with result dotnotation by changing the result Data object type to dynamic.
+
 ## [1.1.0] - 2024-08-20
 ### Updated
 - Updated Newtonsoft.Json library to the latest version 13.0.3.

--- a/Frends.JSON.QuerySingle/Frends.JSON.QuerySingle/Definitions/Result.cs
+++ b/Frends.JSON.QuerySingle/Frends.JSON.QuerySingle/Definitions/Result.cs
@@ -15,7 +15,7 @@ public class Result
     /// Result data.
     /// </summary>
     /// <example>{{ "Name": "Foo", "Products": [{ "Name": "Bar", "Price": 1 }]}}</example>
-    public object Data { get; private set; }
+    public dynamic Data { get; private set; }
 
     internal Result(bool success, object data)
     {

--- a/Frends.JSON.QuerySingle/Frends.JSON.QuerySingle/Frends.JSON.QuerySingle.csproj
+++ b/Frends.JSON.QuerySingle/Frends.JSON.QuerySingle/Frends.JSON.QuerySingle.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 	<TargetFrameworks>net6.0</TargetFrameworks>
-	<Version>1.1.0</Version>
+	<Version>1.2.0</Version>
 	<Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>

--- a/Frends.JSON.QuerySingle/Frends.JSON.QuerySingle/QuerySingle.cs
+++ b/Frends.JSON.QuerySingle/Frends.JSON.QuerySingle/QuerySingle.cs
@@ -27,7 +27,7 @@ public class JSON
     /// </summary>
     /// <param name="input">Input parameters.</param>
     /// <param name="options">Optional parameters.</param>
-    /// <returns>Object { bool Success, object Data }</returns>
+    /// <returns>Object { bool Success, dynamic Data }</returns>
     public static Result QuerySingle([PropertyTab] Input input, [PropertyTab] Options options)
     {
         JToken jToken = GetJTokenFromInput(input.Json);


### PR DESCRIPTION
#30 

## [1.2.0] - 2024-11-07
### Fixed
- Fixed issue with result dotnotation by changing the result Data object type to dynamic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the `Data` property in the result to a dynamic type for improved flexibility in handling various data structures.

- **Bug Fixes**
	- Resolved issues related to result dot notation by modifying the `Data` property type.

- **Documentation**
	- Changelog updated to reflect the new version 1.2.0 and previous updates.
	- Updated return type documentation for the `QuerySingle` method to indicate the change to dynamic data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->