### PR TITLE
feat: XML value type correction via xsi:type / XSD (2.0.0, breaking)

### DIFF
--- a/Frends.JSON.ConvertXMLStringToJToken/CHANGELOG.md
+++ b/Frends.JSON.ConvertXMLStringToJToken/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [2.0.0] - 2026-05-27
+### Breaking
+- The `XSD` parameter has moved from the **Input** tab to the **Options** tab and is now only used (and shown) when `TypeCorrection` is `Schema`.
+  - **Why this is breaking:** the XSD is no longer bound where existing process references expect it. A migration (`migration.json`) ships with the package to copy `Input.XSD` → `Options.XSD` and set `TypeCorrection = Schema` automatically, but **tenants that do not apply migration.json will not migrate automatically**. On those tenants the old XSD value is dropped, so XSD-driven array mapping (added in 1.2.0) silently stops working.
+  - **Upgrade path (manual, for tenants without migration support):** after updating each affected process step, open the **Options** tab, set `TypeCorrection = Schema`, and paste your XSD into `Options.XSD`. This restores the previous array-mapping behaviour. Steps that never used an XSD need no changes — leave `TypeCorrection = None`.
+### Added
+- Added `Options` parameter with `TypeCorrection` (`None`/`Attributes`/`Schema`) to convert numeric and boolean XML values into native JSON types, via inline `xsi:type` attributes (`Attributes`) or the supplied XSD (`Schema`). Default is `None`.
+### Changed
+- In `Schema` mode the XSD now drives both array mapping and value typing. `Schema` mode without an XSD is a graceful no-op (returns string values) rather than an error.
+
 ## [1.2.0] - 2026-05-07
 ### Added
 - Added optional XSD input support to ensure consistent array/object mapping 

--- a/Frends.JSON.ConvertXMLStringToJToken/Frends.JSON.ConvertXMLStringToJToken.Tests/UnitTests.cs
+++ b/Frends.JSON.ConvertXMLStringToJToken/Frends.JSON.ConvertXMLStringToJToken.Tests/UnitTests.cs
@@ -528,6 +528,10 @@ public class UnitTests
         Assert.AreEqual(JTokenType.Boolean, root["inStock"].Type);
         Assert.IsTrue(root["inStock"].Value<bool>());
         Assert.AreEqual(JTokenType.String, root["name"].Type);
+
+        // The xmlns:xsi declaration the task injects to carry derived xsi:type hints must not
+        // leak into the output once those hints have been consumed.
+        Assert.IsNull(root["@xmlns:xsi"]);
     }
 
     [TestMethod]
@@ -680,6 +684,26 @@ public class UnitTests
         var result = JSON.ConvertXMLStringToJToken(input, options);
 
         Assert.IsTrue(result.Success);
+    }
+
+    [TestMethod]
+    public void TypeCorrection_ShouldKeepXsiNamespaceWhenAnXsiAttributeSurvives()
+    {
+        var input = new Input()
+        {
+            XML = @"<root xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
+                      <data xsi:type='hexBinary'>DEADBEEF</data>
+                    </root>"
+        };
+
+        // hexBinary is not convertible, so @xsi:type survives — the xmlns:xsi declaration that
+        // it depends on must be preserved rather than pruned as unused.
+        var result = JSON.ConvertXMLStringToJToken(input, new Options { TypeCorrection = TypeCorrectionMode.Attributes });
+        var root = ((JObject)result.Jtoken)["root"] as JObject;
+
+        Assert.IsNotNull(root);
+        Assert.AreEqual("http://www.w3.org/2001/XMLSchema-instance", root["@xmlns:xsi"]?.ToString());
+        Assert.AreEqual("hexBinary", root["data"]?["@xsi:type"]?.ToString());
     }
 
     [TestMethod]

--- a/Frends.JSON.ConvertXMLStringToJToken/Frends.JSON.ConvertXMLStringToJToken.Tests/UnitTests.cs
+++ b/Frends.JSON.ConvertXMLStringToJToken/Frends.JSON.ConvertXMLStringToJToken.Tests/UnitTests.cs
@@ -242,6 +242,230 @@ public class UnitTests
     }
 
     [TestMethod]
+    public void NoneMode_ShouldNotTouchXsiNilWrappers()
+    {
+        var input = new Input()
+        {
+            XML = @"<root xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
+                      <fax xsi:nil='true'/>
+                      <phone xsi:nil='false'/>
+                    </root>"
+        };
+
+        // In None mode the task does no type/nullability processing, so Newtonsoft's raw
+        // shape (wrapper objects holding @xsi:nil) is preserved verbatim. Anyone relying on
+        // the pre-2.0.0 output stays unaffected by the xsi:nil feature.
+        var result = JSON.ConvertXMLStringToJToken(input, new Options { TypeCorrection = TypeCorrectionMode.None });
+        var root = (JObject)((JObject)result.Jtoken)["root"];
+
+        Assert.AreEqual("true", root["fax"]?["@xsi:nil"]?.ToString());
+        Assert.AreEqual("false", root["phone"]?["@xsi:nil"]?.ToString());
+    }
+
+    [TestMethod]
+    public void AttributesMode_XsiNilTrue_EmptyElement_ShouldBecomeNull()
+    {
+        var input = new Input()
+        {
+            XML = @"<root xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
+                      <fax xsi:nil='true'/>
+                    </root>"
+        };
+
+        var result = JSON.ConvertXMLStringToJToken(input, new Options { TypeCorrection = TypeCorrectionMode.Attributes });
+        var fax = ((JObject)result.Jtoken)["root"]?["fax"];
+
+        Assert.IsNotNull(fax);
+        Assert.AreEqual(JTokenType.Null, fax.Type);
+    }
+
+    [TestMethod]
+    public void AttributesMode_XsiNilTrue_WithContent_ShouldUseContent()
+    {
+        var input = new Input()
+        {
+            XML = @"<root xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
+                      <fax xsi:nil='true'>123</fax>
+                      <count xsi:type='int' xsi:nil='true'>42</count>
+                    </root>"
+        };
+
+        // Content wins over the nil flag: the string "123" survives, and the typed element
+        // still converts to integer 42 via the normal xsi:type path.
+        var result = JSON.ConvertXMLStringToJToken(input, new Options { TypeCorrection = TypeCorrectionMode.Attributes });
+        var root = (JObject)((JObject)result.Jtoken)["root"];
+
+        Assert.AreEqual(JTokenType.String, root["fax"].Type);
+        Assert.AreEqual("123", root["fax"].ToString());
+        Assert.AreEqual(JTokenType.Integer, root["count"].Type);
+        Assert.AreEqual(42, root["count"].Value<int>());
+    }
+
+    [TestMethod]
+    public void AttributesMode_XsiNilFalse_EmptyElement_ShouldUseTypeDefault()
+    {
+        var input = new Input()
+        {
+            XML = @"<root xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
+                      <count xsi:type='int' xsi:nil='false'/>
+                      <ratio xsi:type='float' xsi:nil='false'/>
+                      <inStock xsi:type='boolean' xsi:nil='false'/>
+                    </root>"
+        };
+
+        var result = JSON.ConvertXMLStringToJToken(input, new Options { TypeCorrection = TypeCorrectionMode.Attributes });
+        var root = (JObject)((JObject)result.Jtoken)["root"];
+
+        Assert.AreEqual(JTokenType.Integer, root["count"].Type);
+        Assert.AreEqual(0L, root["count"].Value<long>());
+        Assert.AreEqual(JTokenType.Float, root["ratio"].Type);
+        Assert.AreEqual(0d, root["ratio"].Value<double>());
+        Assert.AreEqual(JTokenType.Boolean, root["inStock"].Type);
+        Assert.IsFalse(root["inStock"].Value<bool>());
+    }
+
+    [TestMethod]
+    public void AttributesMode_XsiNilFalse_WithContent_ShouldStripNilAndKeepContent()
+    {
+        var input = new Input()
+        {
+            XML = @"<root xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
+                      <count xsi:type='int' xsi:nil='false'>5</count>
+                    </root>"
+        };
+
+        var result = JSON.ConvertXMLStringToJToken(input, new Options { TypeCorrection = TypeCorrectionMode.Attributes });
+        var count = ((JObject)result.Jtoken)["root"]?["count"];
+
+        Assert.AreEqual(JTokenType.Integer, count.Type);
+        Assert.AreEqual(5, count.Value<int>());
+    }
+
+    [TestMethod]
+    public void AttributesMode_XsiNilFalse_WithoutTypeInfo_ShouldBeNoOp()
+    {
+        var input = new Input()
+        {
+            XML = @"<root xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
+                      <fax xsi:nil='false'/>
+                    </root>"
+        };
+
+        // No xsi:type → we have no type info to coerce against. Per spec, leave the wrapper
+        // alone (xsi:nil attribute stays so the caller can see the marker if they want).
+        var result = JSON.ConvertXMLStringToJToken(input, new Options { TypeCorrection = TypeCorrectionMode.Attributes });
+        var fax = ((JObject)result.Jtoken)["root"]?["fax"];
+
+        Assert.IsInstanceOfType(fax, typeof(JObject));
+        Assert.AreEqual("false", fax["@xsi:nil"].ToString());
+    }
+
+    [TestMethod]
+    public void AttributesMode_XsiNilFalse_PreservesOtherAttributes()
+    {
+        var input = new Input()
+        {
+            XML = @"<root xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
+                      <price currency='EUR' xsi:type='float' xsi:nil='false'/>
+                    </root>"
+        };
+
+        // Element carries another data attribute, so the wrapper must survive. xsi:nil and
+        // xsi:type are consumed; #text becomes the typed default; @currency stays untouched.
+        var result = JSON.ConvertXMLStringToJToken(input, new Options { TypeCorrection = TypeCorrectionMode.Attributes });
+        var price = ((JObject)result.Jtoken)["root"]?["price"];
+
+        Assert.IsInstanceOfType(price, typeof(JObject));
+        Assert.AreEqual("EUR", price["@currency"].ToString());
+        Assert.IsNull(price["@xsi:type"]);
+        Assert.IsNull(price["@xsi:nil"]);
+        Assert.AreEqual(JTokenType.Float, price["#text"].Type);
+        Assert.AreEqual(0d, price["#text"].Value<double>());
+    }
+
+    [TestMethod]
+    public void AttributesMode_XsiNilFalse_HonoursAliasedPrefix()
+    {
+        var input = new Input()
+        {
+            XML = @"<root xmlns:i='http://www.w3.org/2001/XMLSchema-instance'>
+                      <count i:type='int' i:nil='false'/>
+                    </root>"
+        };
+
+        var result = JSON.ConvertXMLStringToJToken(input, new Options { TypeCorrection = TypeCorrectionMode.Attributes });
+        var count = ((JObject)result.Jtoken)["root"]?["count"];
+
+        Assert.AreEqual(JTokenType.Integer, count.Type);
+        Assert.AreEqual(0L, count.Value<long>());
+    }
+
+    [TestMethod]
+    public void SchemaMode_XsiNilFalse_EmptyStringElement_ShouldBecomeEmptyString()
+    {
+        var input = new Input()
+        {
+            XML = @"<root xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
+                      <name xsi:nil='false'/>
+                    </root>"
+        };
+
+        var options = new Options()
+        {
+            TypeCorrection = TypeCorrectionMode.Schema,
+            XSD = @"<xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema'>
+                      <xs:element name='root'>
+                        <xs:complexType>
+                          <xs:sequence>
+                            <xs:element name='name' type='xs:string' nillable='true' />
+                          </xs:sequence>
+                        </xs:complexType>
+                      </xs:element>
+                    </xs:schema>"
+        };
+
+        // Schema declares the element as xs:string. xsi:nil='false' on an empty element means
+        // "do not allow null" — for a string that's an empty string.
+        var result = JSON.ConvertXMLStringToJToken(input, options);
+        var name = ((JObject)result.Jtoken)["root"]?["name"];
+
+        Assert.IsNotNull(name);
+        Assert.AreEqual(JTokenType.String, name.Type);
+        Assert.AreEqual(string.Empty, name.ToString());
+    }
+
+    [TestMethod]
+    public void SchemaMode_XsiNilTrue_EmptyNillableElement_ShouldBecomeNull()
+    {
+        var input = new Input()
+        {
+            XML = @"<root xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
+                      <fax xsi:nil='true'/>
+                    </root>"
+        };
+
+        var options = new Options()
+        {
+            TypeCorrection = TypeCorrectionMode.Schema,
+            XSD = @"<xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema'>
+                      <xs:element name='root'>
+                        <xs:complexType>
+                          <xs:sequence>
+                            <xs:element name='fax' type='xs:string' nillable='true' />
+                          </xs:sequence>
+                        </xs:complexType>
+                      </xs:element>
+                    </xs:schema>"
+        };
+
+        var result = JSON.ConvertXMLStringToJToken(input, options);
+        var fax = ((JObject)result.Jtoken)["root"]?["fax"];
+
+        Assert.IsNotNull(fax);
+        Assert.AreEqual(JTokenType.Null, fax.Type);
+    }
+
+    [TestMethod]
     public void AttributesMode_ShouldLeaveUnparseableValuesAsStrings()
     {
         var input = new Input()

--- a/Frends.JSON.ConvertXMLStringToJToken/Frends.JSON.ConvertXMLStringToJToken.Tests/UnitTests.cs
+++ b/Frends.JSON.ConvertXMLStringToJToken/Frends.JSON.ConvertXMLStringToJToken.Tests/UnitTests.cs
@@ -1,3 +1,4 @@
+using System;
 using Frends.JSON.ConvertXMLStringToJToken.Definitions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json.Linq;
@@ -238,6 +239,125 @@ public class UnitTests
         Assert.AreEqual(1, scores.Count);
         Assert.AreEqual(JTokenType.Float, scores[0].Type);
         Assert.AreEqual(9.5, scores[0].Value<double>());
+    }
+
+    [TestMethod]
+    public void AttributesMode_ThrowAction_ShouldThrowOnUnparseableValue()
+    {
+        var input = new Input()
+        {
+            XML = @"<root xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
+                      <price xsi:type='float'>not-a-number</price>
+                    </root>"
+        };
+
+        var options = new Options
+        {
+            TypeCorrection = TypeCorrectionMode.Attributes,
+            ActionOnBadValues = BadValueAction.Throw,
+        };
+
+        var ex = Assert.ThrowsException<FormatException>(
+            () => JSON.ConvertXMLStringToJToken(input, options));
+
+        StringAssert.Contains(ex.Message, "not-a-number");
+        StringAssert.Contains(ex.Message, "float");
+    }
+
+    [TestMethod]
+    public void AttributesMode_ThrowAction_ShouldNotThrowWhenAllValuesParse()
+    {
+        var input = new Input()
+        {
+            XML = @"<root xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
+                      <price xsi:type='float'>12.5</price>
+                      <inStock xsi:type='boolean'>true</inStock>
+                    </root>"
+        };
+
+        var options = new Options
+        {
+            TypeCorrection = TypeCorrectionMode.Attributes,
+            ActionOnBadValues = BadValueAction.Throw,
+        };
+
+        var result = JSON.ConvertXMLStringToJToken(input, options);
+        var root = (JObject)((JObject)result.Jtoken)["root"];
+
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(JTokenType.Float, root["price"].Type);
+        Assert.AreEqual(JTokenType.Boolean, root["inStock"].Type);
+    }
+
+    [TestMethod]
+    public void AttributesMode_ThrowAction_ShouldThrowOnUnparseableBoolean()
+    {
+        var input = new Input()
+        {
+            XML = @"<root xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
+                      <inStock xsi:type='boolean'>maybe</inStock>
+                    </root>"
+        };
+
+        var options = new Options
+        {
+            TypeCorrection = TypeCorrectionMode.Attributes,
+            ActionOnBadValues = BadValueAction.Throw,
+        };
+
+        var ex = Assert.ThrowsException<FormatException>(
+            () => JSON.ConvertXMLStringToJToken(input, options));
+
+        StringAssert.Contains(ex.Message, "maybe");
+        StringAssert.Contains(ex.Message, "boolean");
+    }
+
+    [TestMethod]
+    public void AttributesMode_IgnoreAction_IsDefaultAndKeepsUnparseableAsString()
+    {
+        var input = new Input()
+        {
+            XML = @"<root xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
+                      <price xsi:type='float'>not-a-number</price>
+                    </root>"
+        };
+
+        var options = new Options
+        {
+            TypeCorrection = TypeCorrectionMode.Attributes,
+        };
+
+        Assert.AreEqual(BadValueAction.Ignore, options.ActionOnBadValues);
+
+        var result = JSON.ConvertXMLStringToJToken(input, options);
+        var price = ((JObject)result.Jtoken)["root"]?["price"];
+
+        Assert.IsInstanceOfType(price, typeof(JObject));
+        Assert.AreEqual(JTokenType.String, price["#text"].Type);
+        Assert.AreEqual("not-a-number", price["#text"].ToString());
+    }
+
+    [TestMethod]
+    public void AttributesMode_ThrowAction_ShouldNotThrowOnUnknownXsiType()
+    {
+        var input = new Input()
+        {
+            XML = @"<root xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
+                      <data xsi:type='hexBinary'>DEADBEEF</data>
+                    </root>"
+        };
+
+        var options = new Options
+        {
+            TypeCorrection = TypeCorrectionMode.Attributes,
+            ActionOnBadValues = BadValueAction.Throw,
+        };
+
+        // xsi:types we don't know how to convert (e.g. hexBinary) are not treated as "bad" —
+        // they're simply left alone regardless of the action setting.
+        var result = JSON.ConvertXMLStringToJToken(input, options);
+
+        Assert.IsTrue(result.Success);
     }
 
     [TestMethod]

--- a/Frends.JSON.ConvertXMLStringToJToken/Frends.JSON.ConvertXMLStringToJToken.Tests/UnitTests.cs
+++ b/Frends.JSON.ConvertXMLStringToJToken/Frends.JSON.ConvertXMLStringToJToken.Tests/UnitTests.cs
@@ -25,7 +25,7 @@ public class UnitTests
             </root>"
         };
 
-        var result = JSON.ConvertXMLStringToJToken(input);
+        var result = JSON.ConvertXMLStringToJToken(input, new Options());
         Assert.IsTrue(result.Success);
         Assert.IsInstanceOfType(result.Jtoken, typeof(JObject));
     }
@@ -40,7 +40,12 @@ public class UnitTests
                <person id='1'>
                  <name>Alan</name>
                </person>
-             </root>",
+             </root>"
+        };
+
+        var options = new Options()
+        {
+            TypeCorrection = TypeCorrectionMode.Schema,
             XSD = @"<xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema'>
                       <xs:element name='root'>
                         <xs:complexType>
@@ -59,7 +64,7 @@ public class UnitTests
                     </xs:schema>"
         };
 
-        var result = JSON.ConvertXMLStringToJToken(input);
+        var result = JSON.ConvertXMLStringToJToken(input, options);
         var root = ((JObject)result.Jtoken)["root"];
 
         Assert.IsTrue(result.Success);
@@ -72,5 +77,184 @@ public class UnitTests
 
         Assert.AreEqual(1, persons.Count);
         Assert.AreEqual("Alan", persons[0]["name"]?.ToString());
+    }
+
+    [TestMethod]
+    public void NoneMode_ShouldKeepValuesAsStrings()
+    {
+        var input = new Input()
+        {
+            XML = @"<root xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
+                      <price xsi:type='float'>12.5</price>
+                    </root>"
+        };
+
+        var result = JSON.ConvertXMLStringToJToken(input, new Options { TypeCorrection = TypeCorrectionMode.None });
+        var price = ((JObject)result.Jtoken)["root"]?["price"];
+
+        // Default behaviour is unchanged: the xsi:type wrapper and string value are preserved.
+        Assert.IsInstanceOfType(price, typeof(JObject));
+        Assert.AreEqual(JTokenType.String, price["#text"].Type);
+        Assert.AreEqual("12.5", price["#text"].ToString());
+    }
+
+    [TestMethod]
+    public void AttributesMode_ShouldConvertNumericAndBooleanValues()
+    {
+        var input = new Input()
+        {
+            XML = @"<root xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
+                      <price xsi:type='float'>12.5</price>
+                      <quantity xsi:type='int'>3</quantity>
+                      <huge xsi:type='integer'>123456789012345678901234567890</huge>
+                      <inStock xsi:type='boolean'>true</inStock>
+                      <name>Widget</name>
+                    </root>"
+        };
+
+        var result = JSON.ConvertXMLStringToJToken(input, new Options { TypeCorrection = TypeCorrectionMode.Attributes });
+        var root = (JObject)((JObject)result.Jtoken)["root"];
+
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(JTokenType.Float, root["price"].Type);
+        Assert.AreEqual(12.5, root["price"].Value<double>());
+        Assert.AreEqual(JTokenType.Integer, root["quantity"].Type);
+        Assert.AreEqual(3, root["quantity"].Value<int>());
+        Assert.AreEqual(JTokenType.Integer, root["huge"].Type);
+        Assert.AreEqual(JTokenType.Boolean, root["inStock"].Type);
+        Assert.IsTrue(root["inStock"].Value<bool>());
+        Assert.AreEqual(JTokenType.String, root["name"].Type);
+    }
+
+    [TestMethod]
+    public void AttributesMode_ShouldKeepOtherAttributesWhileTypingText()
+    {
+        var input = new Input()
+        {
+            XML = @"<root xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
+                      <price currency='EUR' xsi:type='float'>12.5</price>
+                    </root>"
+        };
+
+        var result = JSON.ConvertXMLStringToJToken(input, new Options { TypeCorrection = TypeCorrectionMode.Attributes });
+        var price = ((JObject)result.Jtoken)["root"]?["price"];
+
+        // Element carries another attribute, so the wrapper is preserved but #text becomes a number.
+        Assert.IsInstanceOfType(price, typeof(JObject));
+        Assert.AreEqual("EUR", price["@currency"].ToString());
+        Assert.IsNull(price["@xsi:type"]);
+        Assert.AreEqual(JTokenType.Float, price["#text"].Type);
+        Assert.AreEqual(12.5, price["#text"].Value<double>());
+    }
+
+    [TestMethod]
+    public void AttributesMode_ShouldLeaveUnparseableValuesAsStrings()
+    {
+        var input = new Input()
+        {
+            XML = @"<root xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
+                      <price xsi:type='float'>not-a-number</price>
+                    </root>"
+        };
+
+        var result = JSON.ConvertXMLStringToJToken(input, new Options { TypeCorrection = TypeCorrectionMode.Attributes });
+        var price = ((JObject)result.Jtoken)["root"]?["price"];
+
+        Assert.IsInstanceOfType(price, typeof(JObject));
+        Assert.AreEqual(JTokenType.String, price["#text"].Type);
+        Assert.AreEqual("not-a-number", price["#text"].ToString());
+    }
+
+    [TestMethod]
+    public void SchemaMode_ShouldConvertValuesUsingXsdTypes()
+    {
+        var input = new Input()
+        {
+            XML = @"<root>
+                      <price>12.5</price>
+                      <quantity>3</quantity>
+                      <inStock>true</inStock>
+                      <name>Widget</name>
+                    </root>"
+        };
+
+        var options = new Options()
+        {
+            TypeCorrection = TypeCorrectionMode.Schema,
+            XSD = @"<xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema'>
+                      <xs:element name='root'>
+                        <xs:complexType>
+                          <xs:sequence>
+                            <xs:element name='price' type='xs:float' />
+                            <xs:element name='quantity' type='xs:int' />
+                            <xs:element name='inStock' type='xs:boolean' />
+                            <xs:element name='name' type='xs:string' />
+                          </xs:sequence>
+                        </xs:complexType>
+                      </xs:element>
+                    </xs:schema>"
+        };
+
+        var result = JSON.ConvertXMLStringToJToken(input, options);
+        var root = (JObject)((JObject)result.Jtoken)["root"];
+
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(JTokenType.Float, root["price"].Type);
+        Assert.AreEqual(12.5, root["price"].Value<double>());
+        Assert.AreEqual(JTokenType.Integer, root["quantity"].Type);
+        Assert.AreEqual(JTokenType.Boolean, root["inStock"].Type);
+        Assert.IsTrue(root["inStock"].Value<bool>());
+        Assert.AreEqual(JTokenType.String, root["name"].Type);
+    }
+
+    [TestMethod]
+    public void SchemaMode_ShouldConvertSingleElementArraysToTypedArrays()
+    {
+        var input = new Input()
+        {
+            XML = @"<root>
+                      <score>9.5</score>
+                    </root>"
+        };
+
+        var options = new Options()
+        {
+            TypeCorrection = TypeCorrectionMode.Schema,
+            XSD = @"<xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema'>
+                      <xs:element name='root'>
+                        <xs:complexType>
+                          <xs:sequence>
+                            <xs:element name='score' type='xs:double' maxOccurs='unbounded' />
+                          </xs:sequence>
+                        </xs:complexType>
+                      </xs:element>
+                    </xs:schema>"
+        };
+
+        var result = JSON.ConvertXMLStringToJToken(input, options);
+        var scores = ((JObject)result.Jtoken)["root"]?["score"] as JArray;
+
+        Assert.IsNotNull(scores);
+        Assert.AreEqual(1, scores.Count);
+        Assert.AreEqual(JTokenType.Float, scores[0].Type);
+        Assert.AreEqual(9.5, scores[0].Value<double>());
+    }
+
+    [TestMethod]
+    public void SchemaMode_WithoutXsd_ShouldNoOpAndKeepStrings()
+    {
+        var input = new Input()
+        {
+            XML = "<root><price>12.5</price></root>"
+        };
+
+        // Schema mode without an XSD is a graceful no-op (not an error), so migrated
+        // processes that land in Schema mode without a schema keep their previous output.
+        var result = JSON.ConvertXMLStringToJToken(input, new Options { TypeCorrection = TypeCorrectionMode.Schema });
+        var price = ((JObject)result.Jtoken)["root"]?["price"];
+
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(JTokenType.String, price.Type);
+        Assert.AreEqual("12.5", price.ToString());
     }
 }

--- a/Frends.JSON.ConvertXMLStringToJToken/Frends.JSON.ConvertXMLStringToJToken.Tests/UnitTests.cs
+++ b/Frends.JSON.ConvertXMLStringToJToken/Frends.JSON.ConvertXMLStringToJToken.Tests/UnitTests.cs
@@ -91,10 +91,12 @@ public class UnitTests
         };
 
         var result = JSON.ConvertXMLStringToJToken(input, new Options { TypeCorrection = TypeCorrectionMode.None });
-        var price = ((JObject)result.Jtoken)["root"]?["price"];
+        Assert.IsTrue(result.Success);
+
+        var price = ((JObject)result.Jtoken)["root"]?["price"] as JObject;
 
         // Default behaviour is unchanged: the xsi:type wrapper and string value are preserved.
-        Assert.IsInstanceOfType(price, typeof(JObject));
+        Assert.IsNotNull(price);
         Assert.AreEqual(JTokenType.String, price["#text"].Type);
         Assert.AreEqual("12.5", price["#text"].ToString());
     }
@@ -149,6 +151,97 @@ public class UnitTests
     }
 
     [TestMethod]
+    public void AttributesMode_BooleanParsing_ShouldBeCaseSensitive()
+    {
+        var input = new Input()
+        {
+            XML = @"<root xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
+                      <lower xsi:type='boolean'>true</lower>
+                      <upper xsi:type='boolean'>TRUE</upper>
+                      <camel xsi:type='boolean'>True</camel>
+                    </root>"
+        };
+
+        var result = JSON.ConvertXMLStringToJToken(input, new Options { TypeCorrection = TypeCorrectionMode.Attributes });
+        var root = (JObject)((JObject)result.Jtoken)["root"];
+
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(JTokenType.Boolean, root["lower"].Type);
+        Assert.IsTrue(root["lower"].Value<bool>());
+
+        Assert.AreEqual(JTokenType.Boolean, root["upper"].Type);
+        Assert.IsTrue(root["upper"].Value<bool>());
+
+        Assert.AreEqual(JTokenType.Boolean, root["camel"].Type);
+        Assert.IsTrue(root["camel"].Value<bool>());
+    }
+
+    [TestMethod]
+    public void AttributesMode_ShouldHonourAliasedXsiNamespacePrefix()
+    {
+        var input = new Input()
+        {
+            XML = @"<root xmlns:i='http://www.w3.org/2001/XMLSchema-instance'>
+                      <price i:type='float'>12.5</price>
+                      <inStock i:type='boolean'>true</inStock>
+                    </root>"
+        };
+
+        // Author used 'i' instead of the conventional 'xsi' prefix; conversion must still fire
+        // because the prefix is resolved against the XML Schema Instance namespace URI.
+        var result = JSON.ConvertXMLStringToJToken(input, new Options { TypeCorrection = TypeCorrectionMode.Attributes });
+        var root = (JObject)((JObject)result.Jtoken)["root"];
+
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(JTokenType.Float, root["price"].Type);
+        Assert.AreEqual(12.5, root["price"].Value<double>());
+        Assert.AreEqual(JTokenType.Boolean, root["inStock"].Type);
+        Assert.IsTrue(root["inStock"].Value<bool>());
+    }
+
+    [TestMethod]
+    public void AttributesMode_ShouldIgnoreTypePropertyWhenPrefixNotBoundToXsiNamespace()
+    {
+        var input = new Input()
+        {
+            XML = @"<root xmlns:cust='http://example.com/custom'>
+                      <price cust:type='float'>12.5</price>
+                    </root>"
+        };
+
+        // 'cust' is bound to an unrelated namespace, so cust:type is just an arbitrary attribute
+        // and must not trigger conversion.
+        var result = JSON.ConvertXMLStringToJToken(input, new Options { TypeCorrection = TypeCorrectionMode.Attributes });
+        var price = ((JObject)result.Jtoken)["root"]?["price"];
+
+        Assert.IsInstanceOfType(price, typeof(JObject));
+        Assert.AreEqual("float", price["@cust:type"]?.ToString());
+        Assert.AreEqual(JTokenType.String, price["#text"].Type);
+        Assert.AreEqual("12.5", price["#text"].ToString());
+    }
+
+    [TestMethod]
+    public void AttributesMode_ShouldResolvePrefixDeclaredOnInnerElement()
+    {
+        var input = new Input()
+        {
+            XML = @"<root>
+                      <wrapper xmlns:i='http://www.w3.org/2001/XMLSchema-instance'>
+                        <price i:type='float'>12.5</price>
+                      </wrapper>
+                    </root>"
+        };
+
+        // The xsi-equivalent prefix is bound on <wrapper>, not on the root — the scope must
+        // still be visible to the inner <price> element when we resolve i:type.
+        var result = JSON.ConvertXMLStringToJToken(input, new Options { TypeCorrection = TypeCorrectionMode.Attributes });
+        var price = ((JObject)result.Jtoken)["root"]?["wrapper"]?["price"];
+
+        Assert.AreEqual(JTokenType.Float, price.Type);
+        Assert.AreEqual(12.5, price.Value<double>());
+    }
+
+    [TestMethod]
     public void AttributesMode_ShouldLeaveUnparseableValuesAsStrings()
     {
         var input = new Input()
@@ -197,9 +290,11 @@ public class UnitTests
         };
 
         var result = JSON.ConvertXMLStringToJToken(input, options);
-        var root = (JObject)((JObject)result.Jtoken)["root"];
-
         Assert.IsTrue(result.Success);
+
+        var root = ((JObject)result.Jtoken)["root"] as JObject;
+        Assert.IsNotNull(root);
+
         Assert.AreEqual(JTokenType.Float, root["price"].Type);
         Assert.AreEqual(12.5, root["price"].Value<double>());
         Assert.AreEqual(JTokenType.Integer, root["quantity"].Type);
@@ -361,6 +456,107 @@ public class UnitTests
     }
 
     [TestMethod]
+    public void SchemaMode_ShouldHonourAliasedXsiNamespacePrefix()
+    {
+        var input = new Input()
+        {
+            XML = @"<root xmlns:i='http://www.w3.org/2001/XMLSchema-instance'>
+                      <price>12.5</price>
+                    </root>"
+        };
+
+        var options = new Options()
+        {
+            TypeCorrection = TypeCorrectionMode.Schema,
+            XSD = @"<xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema'>
+                      <xs:element name='root'>
+                        <xs:complexType>
+                          <xs:sequence>
+                            <xs:element name='price' type='xs:float' />
+                          </xs:sequence>
+                        </xs:complexType>
+                      </xs:element>
+                    </xs:schema>"
+        };
+
+        // Root already binds the XSD-instance namespace under prefix 'i'. The schema-injected
+        // type attribute should serialize as @i:type and the prefix-agnostic lookup must still
+        // resolve it for conversion.
+        var result = JSON.ConvertXMLStringToJToken(input, options);
+        var price = ((JObject)result.Jtoken)["root"]?["price"];
+
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(JTokenType.Float, price.Type);
+        Assert.AreEqual(12.5, price.Value<double>());
+    }
+
+    [TestMethod]
+    public void SchemaMode_ShouldOverrideInlineXsiTypeWithSchemaType()
+    {
+        var input = new Input()
+        {
+            XML = @"<root xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
+                      <price xsi:type='int'>12.5</price>
+                    </root>"
+        };
+
+        var options = new Options()
+        {
+            TypeCorrection = TypeCorrectionMode.Schema,
+            XSD = @"<xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema'>
+                      <xs:element name='root'>
+                        <xs:complexType>
+                          <xs:sequence>
+                            <xs:element name='price' type='xs:float' />
+                          </xs:sequence>
+                        </xs:complexType>
+                      </xs:element>
+                    </xs:schema>"
+        };
+
+        // The author lied with xsi:type='int' on a 12.5 value; schema says float. XSD wins.
+        var result = JSON.ConvertXMLStringToJToken(input, options);
+        var price = ((JObject)result.Jtoken)["root"]?["price"];
+
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(JTokenType.Float, price.Type);
+        Assert.AreEqual(12.5, price.Value<double>());
+    }
+
+    [TestMethod]
+    public void SchemaMode_ShouldStripInlineXsiTypeWhenSchemaTypeIsString()
+    {
+        var input = new Input()
+        {
+            XML = @"<root xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
+                      <name xsi:type='int'>42</name>
+                    </root>"
+        };
+
+        var options = new Options()
+        {
+            TypeCorrection = TypeCorrectionMode.Schema,
+            XSD = @"<xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema'>
+                      <xs:element name='root'>
+                        <xs:complexType>
+                          <xs:sequence>
+                            <xs:element name='name' type='xs:string' />
+                          </xs:sequence>
+                        </xs:complexType>
+                      </xs:element>
+                    </xs:schema>"
+        };
+
+        // Inline xsi:type='int' must not override the schema's xs:string declaration.
+        var result = JSON.ConvertXMLStringToJToken(input, options);
+        var name = ((JObject)result.Jtoken)["root"]?["name"];
+
+        Assert.IsTrue(result.Success);
+        Assert.AreEqual(JTokenType.String, name.Type);
+        Assert.AreEqual("42", name.ToString());
+    }
+
+    [TestMethod]
     public void SchemaMode_WithoutXsd_ShouldNoOpAndKeepStrings()
     {
         var input = new Input()
@@ -371,10 +567,34 @@ public class UnitTests
         // Schema mode without an XSD is a graceful no-op (not an error), so migrated
         // processes that land in Schema mode without a schema keep their previous output.
         var result = JSON.ConvertXMLStringToJToken(input, new Options { TypeCorrection = TypeCorrectionMode.Schema });
+        Assert.IsTrue(result.Success);
+
+        var price = ((JObject)result.Jtoken)["root"]?["price"];
+        Assert.IsNotNull(price);
+        Assert.AreEqual(JTokenType.String, price.Type);
+        Assert.AreEqual("12.5", price.ToString());
+    }
+
+    [TestMethod]
+    public void SchemaMode_WithoutXsd_ShouldNotConvertInlineXsiTypes()
+    {
+        var input = new Input()
+        {
+            XML = @"<root xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
+                      <price xsi:type='float'>12.5</price>
+                    </root>"
+        };
+
+        // Schema-without-XSD is a true no-op: inline xsi:type must not bleed through and
+        // start converting values either. Tenants who land here via migration with no XSD
+        // should see exactly the pre-2.0.0 output shape.
+        var result = JSON.ConvertXMLStringToJToken(input, new Options { TypeCorrection = TypeCorrectionMode.Schema });
         var price = ((JObject)result.Jtoken)["root"]?["price"];
 
         Assert.IsTrue(result.Success);
-        Assert.AreEqual(JTokenType.String, price.Type);
-        Assert.AreEqual("12.5", price.ToString());
+        Assert.IsInstanceOfType(price, typeof(JObject));
+        Assert.AreEqual("float", price["@xsi:type"]?.ToString());
+        Assert.AreEqual(JTokenType.String, price["#text"].Type);
+        Assert.AreEqual("12.5", price["#text"].ToString());
     }
 }

--- a/Frends.JSON.ConvertXMLStringToJToken/Frends.JSON.ConvertXMLStringToJToken.Tests/UnitTests.cs
+++ b/Frends.JSON.ConvertXMLStringToJToken/Frends.JSON.ConvertXMLStringToJToken.Tests/UnitTests.cs
@@ -310,6 +310,7 @@ public class UnitTests
                       <count xsi:type='int' xsi:nil='false'/>
                       <ratio xsi:type='float' xsi:nil='false'/>
                       <inStock xsi:type='boolean' xsi:nil='false'/>
+                      <str xsi:type='string' xsi:nil='false'/>
                     </root>"
         };
 
@@ -322,6 +323,8 @@ public class UnitTests
         Assert.AreEqual(0d, root["ratio"].Value<double>());
         Assert.AreEqual(JTokenType.Boolean, root["inStock"].Type);
         Assert.IsFalse(root["inStock"].Value<bool>());
+        Assert.AreEqual(JTokenType.String, root["str"].Type);
+        Assert.AreEqual(string.Empty,  root["str"].Value<string>());
     }
 
     [TestMethod]

--- a/Frends.JSON.ConvertXMLStringToJToken/Frends.JSON.ConvertXMLStringToJToken.Tests/UnitTests.cs
+++ b/Frends.JSON.ConvertXMLStringToJToken/Frends.JSON.ConvertXMLStringToJToken.Tests/UnitTests.cs
@@ -324,7 +324,7 @@ public class UnitTests
         Assert.AreEqual(JTokenType.Boolean, root["inStock"].Type);
         Assert.IsFalse(root["inStock"].Value<bool>());
         Assert.AreEqual(JTokenType.String, root["str"].Type);
-        Assert.AreEqual(string.Empty,  root["str"].Value<string>());
+        Assert.AreEqual(string.Empty, root["str"].Value<string>());
     }
 
     [TestMethod]

--- a/Frends.JSON.ConvertXMLStringToJToken/Frends.JSON.ConvertXMLStringToJToken/ConvertXMLStringToJToken.cs
+++ b/Frends.JSON.ConvertXMLStringToJToken/Frends.JSON.ConvertXMLStringToJToken/ConvertXMLStringToJToken.cs
@@ -1,9 +1,13 @@
 using Frends.JSON.ConvertXMLStringToJToken.Definitions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Numerics;
 using System.Xml;
 using System.Xml.Linq;
 using System.Xml.Schema;
@@ -16,21 +20,63 @@ namespace Frends.JSON.ConvertXMLStringToJToken;
 public class JSON
 {
     private const string JsonNamespace = "http://james.newtonking.com/projects/json";
+    private const string XsiNamespace = "http://www.w3.org/2001/XMLSchema-instance";
+
+    private const string TextPropertyName = "#text";
+    private const string XsiTypePropertyName = "@xsi:type";
+
+    /// <summary>
+    /// Maps an XSD type local name to a parser producing a native JSON value, or null when unparseable.
+    /// </summary>
+    private static readonly Dictionary<string, Func<string, JValue>> TypeConverters =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["float"] = ParseFloatingPoint,
+            ["double"] = ParseFloatingPoint,
+            ["decimal"] = ParseDecimal,
+            ["int"] = ParseInteger,
+            ["integer"] = ParseInteger,
+            ["long"] = ParseInteger,
+            ["short"] = ParseInteger,
+            ["byte"] = ParseInteger,
+            ["unsignedInt"] = ParseInteger,
+            ["unsignedLong"] = ParseInteger,
+            ["unsignedShort"] = ParseInteger,
+            ["unsignedByte"] = ParseInteger,
+            ["nonNegativeInteger"] = ParseInteger,
+            ["positiveInteger"] = ParseInteger,
+            ["nonPositiveInteger"] = ParseInteger,
+            ["negativeInteger"] = ParseInteger,
+            ["boolean"] = ParseBoolean,
+        };
 
     /// <summary>
     /// Convert XML string to JToken.
     /// [Documentation](https://tasks.frends.com/tasks/frends-tasks/Frends.JSON.ConvertXMLStringToJToken)
     /// </summary>
     /// <param name="input">Input parameters</param>
+    /// <param name="options">Optional parameters</param>
     /// <returns>Object { bool Success, object Jtoken }</returns>
-    public static Result ConvertXMLStringToJToken([PropertyTab] Input input)
+    public static Result ConvertXMLStringToJToken([PropertyTab] Input input, [PropertyTab] Options options)
     {
-        var doc = string.IsNullOrWhiteSpace(input.XSD)
-            ? LoadXmlDocument(input.XML)
-            : LoadXmlDocumentWithSchemaHints(input.XML, input.XSD);
+        options ??= new Options();
+
+        // Schema mode without an XSD is treated as a no-op rather than an error so that
+        // processes migrated into Schema mode without a schema keep their previous output.
+        var useSchema = options.TypeCorrection == TypeCorrectionMode.Schema
+            && !string.IsNullOrWhiteSpace(options.XSD);
+
+        var doc = useSchema
+            ? LoadXmlDocumentWithSchemaHints(input.XML, options.XSD, options.TypeCorrection)
+            : LoadXmlDocument(input.XML);
 
         var jsonString = JsonConvert.SerializeXmlNode(doc);
-        return new Result(true, JToken.Parse(jsonString));
+        var token = JToken.Parse(jsonString);
+
+        if (options.TypeCorrection != TypeCorrectionMode.None)
+            CorrectTypes(token);
+
+        return new Result(true, token);
     }
 
     private static XmlDocument LoadXmlDocument(string xml)
@@ -40,7 +86,7 @@ public class JSON
         return doc;
     }
 
-    private static XmlDocument LoadXmlDocumentWithSchemaHints(string xml, string xsd)
+    private static XmlDocument LoadXmlDocumentWithSchemaHints(string xml, string xsd, TypeCorrectionMode typeCorrection)
     {
         var schemaSet = CreateSchemaSet(xsd);
 
@@ -56,7 +102,7 @@ public class JSON
             },
             true);
 
-        AddJsonArrayAttributesFromSchema(xDocument);
+        AddSchemaHints(xDocument, typeCorrection);
 
         var xmlDocument = new XmlDocument();
 
@@ -75,35 +121,195 @@ public class JSON
         return schemaSet;
     }
 
-    private static void AddJsonArrayAttributesFromSchema(XDocument document)
+    /// <summary>
+    /// Walks the validated document once, tagging elements that the schema declares as
+    /// repeatable with json:Array, and (when requested) numeric/boolean elements with xsi:type
+    /// so they can be converted to native JSON types after serialization.
+    /// </summary>
+    private static void AddSchemaHints(XDocument document, TypeCorrectionMode typeCorrection)
     {
         if (document.Root == null)
             return;
 
         XNamespace jsonNs = JsonNamespace;
+        XNamespace xsiNs = XsiNamespace;
         var hasArray = false;
+        var hasType = false;
 
         foreach (var element in document.Root.DescendantsAndSelf())
         {
-            var schemaElement = element.GetSchemaInfo()?.SchemaElement;
+            var schemaInfo = element.GetSchemaInfo();
+            var schemaElement = schemaInfo?.SchemaElement;
 
             if (schemaElement?.MaxOccurs > 1m)
             {
                 element.SetAttributeValue(jsonNs + "Array", "true");
                 hasArray = true;
             }
+
+            if (typeCorrection == TypeCorrectionMode.Schema)
+            {
+                var typeName = GetConvertibleTypeName(schemaInfo?.SchemaType);
+                if (typeName != null)
+                {
+                    element.SetAttributeValue(xsiNs + "type", typeName);
+                    hasType = true;
+                }
+            }
         }
 
-        var existing = document.Root.Attributes()
-            .FirstOrDefault(a =>
-                a.IsNamespaceDeclaration &&
-                a.Value == JsonNamespace);
+        if (hasArray && !IsNamespaceDeclared(document.Root, JsonNamespace))
+            document.Root.SetAttributeValue(XNamespace.Xmlns + "json", JsonNamespace);
 
-        if (hasArray && existing == null)
+        // Pin the "xsi" prefix so injected type hints serialize as @xsi:type rather than an
+        // auto-generated prefix that the post-serialization conversion would not recognise.
+        if (hasType && !IsNamespaceDeclared(document.Root, XsiNamespace))
+            document.Root.SetAttributeValue(XNamespace.Xmlns + "xsi", XsiNamespace);
+    }
+
+    private static bool IsNamespaceDeclared(XElement root, string namespaceName)
+    {
+        return root.Attributes().Any(a => a.IsNamespaceDeclaration && a.Value == namespaceName);
+    }
+
+    /// <summary>
+    /// Returns a canonical XSD type name (matching <see cref="TypeConverters"/>) for numeric/boolean
+    /// schema types, or null for types that should remain strings.
+    /// </summary>
+    private static string GetConvertibleTypeName(XmlSchemaType schemaType)
+    {
+        return schemaType?.TypeCode switch
         {
-            document.Root.SetAttributeValue(
-                XNamespace.Xmlns + "json",
-                JsonNamespace);
+            XmlTypeCode.Float => "float",
+            XmlTypeCode.Double => "double",
+            XmlTypeCode.Decimal => "decimal",
+            XmlTypeCode.Boolean => "boolean",
+            XmlTypeCode.Integer
+                or XmlTypeCode.NonPositiveInteger
+                or XmlTypeCode.NegativeInteger
+                or XmlTypeCode.Long
+                or XmlTypeCode.Int
+                or XmlTypeCode.Short
+                or XmlTypeCode.Byte
+                or XmlTypeCode.NonNegativeInteger
+                or XmlTypeCode.UnsignedLong
+                or XmlTypeCode.UnsignedInt
+                or XmlTypeCode.UnsignedShort
+                or XmlTypeCode.UnsignedByte
+                or XmlTypeCode.PositiveInteger => "integer",
+            _ => null,
+        };
+    }
+
+    /// <summary>
+    /// Recursively converts values carrying an xsi:type hint into native JSON numbers/booleans,
+    /// removing the consumed xsi:type attribute and collapsing the wrapper object when only the
+    /// converted value remains.
+    /// </summary>
+    private static void CorrectTypes(JToken token)
+    {
+        switch (token)
+        {
+            case JArray array:
+                foreach (var item in array.Children().ToList())
+                    CorrectTypes(item);
+                break;
+
+            case JObject obj:
+                foreach (var value in obj.PropertyValues().ToList())
+                    CorrectTypes(value);
+                ApplyTypeHint(obj);
+                break;
+        }
+    }
+
+    private static void ApplyTypeHint(JObject obj)
+    {
+        var typeProperty = obj.Property(XsiTypePropertyName, StringComparison.Ordinal);
+        if (typeProperty == null)
+            return;
+
+        var typeName = LocalName(typeProperty.Value.ToString());
+        if (!TypeConverters.TryGetValue(typeName, out var convert))
+            return;
+
+        var textProperty = obj.Property(TextPropertyName, StringComparison.Ordinal);
+        if (textProperty == null || textProperty.Value.Type != JTokenType.String)
+            return;
+
+        var converted = convert(textProperty.Value.ToString());
+        if (converted == null)
+            return;
+
+        typeProperty.Remove();
+
+        var remaining = obj.Properties().ToList();
+        var onlyText = remaining.Count == 1 && remaining[0].Name == TextPropertyName;
+        var onlyTextAndXsiNs = remaining.Count == 2 &&
+            remaining.Any(p => p.Name == TextPropertyName) &&
+            remaining.Any(IsXsiNamespaceDeclaration);
+
+        if ((onlyText || onlyTextAndXsiNs) && obj.Parent != null)
+            obj.Replace(converted);
+        else
+            textProperty.Value = converted;
+    }
+
+    private static bool IsXsiNamespaceDeclaration(JProperty property)
+    {
+        return property.Name.StartsWith("@xmlns", StringComparison.Ordinal) &&
+            string.Equals(property.Value.ToString(), XsiNamespace, StringComparison.Ordinal);
+    }
+
+    private static string LocalName(string value)
+    {
+        var index = value.IndexOf(':');
+        return index >= 0 ? value[(index + 1)..] : value;
+    }
+
+    private static JValue ParseFloatingPoint(string value)
+    {
+        switch (value.Trim())
+        {
+            case "INF": return new JValue(double.PositiveInfinity);
+            case "-INF": return new JValue(double.NegativeInfinity);
+            case "NaN": return new JValue(double.NaN);
+        }
+
+        return double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed)
+            ? new JValue(parsed)
+            : null;
+    }
+
+    private static JValue ParseDecimal(string value)
+    {
+        return decimal.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed)
+            ? new JValue(parsed)
+            : null;
+    }
+
+    private static JValue ParseInteger(string value)
+    {
+        if (long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedLong))
+            return new JValue(parsedLong);
+
+        return BigInteger.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedBig)
+            ? new JValue(parsedBig)
+            : null;
+    }
+
+    private static JValue ParseBoolean(string value)
+    {
+        switch (value.Trim())
+        {
+            case "true":
+            case "1":
+                return new JValue(true);
+            case "false":
+            case "0":
+                return new JValue(false);
+            default:
+                return null;
         }
     }
 }

--- a/Frends.JSON.ConvertXMLStringToJToken/Frends.JSON.ConvertXMLStringToJToken/ConvertXMLStringToJToken.cs
+++ b/Frends.JSON.ConvertXMLStringToJToken/Frends.JSON.ConvertXMLStringToJToken/ConvertXMLStringToJToken.cs
@@ -74,7 +74,7 @@ public class JSON
         var token = JToken.Parse(jsonString);
 
         if (options.TypeCorrection != TypeCorrectionMode.None)
-            CorrectTypes(token);
+            CorrectTypes(token, options.ActionOnBadValues);
 
         return new Result(true, token);
     }
@@ -206,24 +206,24 @@ public class JSON
     /// removing the consumed xsi:type attribute and collapsing the wrapper object when only the
     /// converted value remains.
     /// </summary>
-    private static void CorrectTypes(JToken token)
+    private static void CorrectTypes(JToken token, BadValueAction actionOnBadValues)
     {
         switch (token)
         {
             case JArray array:
                 foreach (var item in array.Children().ToList())
-                    CorrectTypes(item);
+                    CorrectTypes(item, actionOnBadValues);
                 break;
 
             case JObject obj:
                 foreach (var value in obj.PropertyValues().ToList())
-                    CorrectTypes(value);
-                ApplyTypeHint(obj);
+                    CorrectTypes(value, actionOnBadValues);
+                ApplyTypeHint(obj, actionOnBadValues);
                 break;
         }
     }
 
-    private static void ApplyTypeHint(JObject obj)
+    private static void ApplyTypeHint(JObject obj, BadValueAction actionOnBadValues)
     {
         var typeProperty = obj.Property(XsiTypePropertyName, StringComparison.Ordinal);
         if (typeProperty == null)
@@ -237,9 +237,15 @@ public class JSON
         if (textProperty == null || textProperty.Value.Type != JTokenType.String)
             return;
 
-        var converted = convert(textProperty.Value.ToString());
+        var rawValue = textProperty.Value.ToString();
+        var converted = convert(rawValue);
         if (converted == null)
+        {
+            if (actionOnBadValues == BadValueAction.Throw)
+                throw new FormatException(
+                    $"Value '{rawValue}' on <{obj.Path}> could not be converted to '{typeName}'.");
             return;
+        }
 
         typeProperty.Remove();
 

--- a/Frends.JSON.ConvertXMLStringToJToken/Frends.JSON.ConvertXMLStringToJToken/ConvertXMLStringToJToken.cs
+++ b/Frends.JSON.ConvertXMLStringToJToken/Frends.JSON.ConvertXMLStringToJToken/ConvertXMLStringToJToken.cs
@@ -86,7 +86,14 @@ public class JSON
                 : TypeCorrectionMode.None;
 
         if (effectiveMode != TypeCorrectionMode.None)
+        {
             CorrectTypes(token, options.ActionOnBadValues, effectiveMode);
+
+            // Schema mode injects an xmlns:xsi declaration to carry the derived xsi:type hints
+            // (see AddSchemaHints). Once CorrectTypes has consumed those hints the declaration is
+            // orphaned, so strip it (and any other now-unused xsi declaration) from the output.
+            RemoveUnusedXsiNamespaceDeclarations(token);
+        }
 
         return new Result(true, token);
     }
@@ -537,6 +544,68 @@ public class JSON
             "boolean" => new JValue(false),
             _ => new JValue(0L),
         };
+    }
+
+    /// <summary>
+    /// Removes XML Schema Instance namespace declarations (e.g. @xmlns:xsi) that no surviving
+    /// xsi:-prefixed attribute still references. Declarations bound to a prefix that is still in
+    /// use (e.g. an unconverted xsi:type or a retained xsi:nil) are left intact.
+    /// </summary>
+    private static void RemoveUnusedXsiNamespaceDeclarations(JToken token)
+    {
+        switch (token)
+        {
+            case JArray array:
+                foreach (var item in array.Children().ToList())
+                    RemoveUnusedXsiNamespaceDeclarations(item);
+                break;
+
+            case JObject obj:
+                var declarations = obj.Properties()
+                    .Where(p => p.Name.StartsWith(XmlnsPrefixSeparator, StringComparison.Ordinal)
+                        && IsXsiNamespaceDeclaration(p))
+                    .ToList();
+
+                foreach (var declaration in declarations)
+                {
+                    var prefix = declaration.Name.Substring(XmlnsPrefixSeparator.Length);
+                    if (!IsPrefixedAttributeUsed(obj, "@" + prefix + ":"))
+                        declaration.Remove();
+                }
+
+                foreach (var value in obj.PropertyValues().ToList())
+                    RemoveUnusedXsiNamespaceDeclarations(value);
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Returns true when any attribute named "&lt;marker&gt;..." (e.g. "@xsi:") appears on this
+    /// token or anywhere in its subtree — the scope over which a namespace declaration applies.
+    /// </summary>
+    private static bool IsPrefixedAttributeUsed(JToken token, string marker)
+    {
+        switch (token)
+        {
+            case JObject obj:
+                foreach (var prop in obj.Properties())
+                {
+                    if (prop.Name.StartsWith(marker, StringComparison.Ordinal))
+                        return true;
+                    if (IsPrefixedAttributeUsed(prop.Value, marker))
+                        return true;
+                }
+                return false;
+
+            case JArray array:
+                foreach (var item in array.Children())
+                    if (IsPrefixedAttributeUsed(item, marker))
+                        return true;
+                return false;
+
+            default:
+                return false;
+        }
     }
 
     private static bool IsXsiNamespaceDeclaration(JProperty property)

--- a/Frends.JSON.ConvertXMLStringToJToken/Frends.JSON.ConvertXMLStringToJToken/ConvertXMLStringToJToken.cs
+++ b/Frends.JSON.ConvertXMLStringToJToken/Frends.JSON.ConvertXMLStringToJToken/ConvertXMLStringToJToken.cs
@@ -79,8 +79,14 @@ public class JSON
         // Attributes always runs; Schema mode only runs when it has an XSD to derive types from,
         // so picking Schema with a blank XSD stays a true no-op even if the input XML happens to
         // carry inline xsi:type attributes.
-        if (options.TypeCorrection == TypeCorrectionMode.Attributes || useSchema)
-            CorrectTypes(token, options.ActionOnBadValues);
+        var effectiveMode = useSchema
+            ? TypeCorrectionMode.Schema
+            : options.TypeCorrection == TypeCorrectionMode.Attributes
+                ? TypeCorrectionMode.Attributes
+                : TypeCorrectionMode.None;
+
+        if (effectiveMode != TypeCorrectionMode.None)
+            CorrectTypes(token, options.ActionOnBadValues, effectiveMode);
 
         return new Result(true, token);
     }
@@ -234,27 +240,34 @@ public class JSON
     /// removing the consumed xsi:type attribute and collapsing the wrapper object when only the
     /// converted value remains.
     /// </summary>
-    private static void CorrectTypes(JToken token, BadValueAction actionOnBadValues)
+    private static void CorrectTypes(JToken token, BadValueAction actionOnBadValues, TypeCorrectionMode mode)
     {
-        CorrectTypes(token, actionOnBadValues, EmptyXmlnsScope);
+        CorrectTypes(token, actionOnBadValues, mode, EmptyXmlnsScope);
     }
 
     private static void CorrectTypes(
         JToken token,
         BadValueAction actionOnBadValues,
+        TypeCorrectionMode mode,
         IReadOnlyDictionary<string, string> xmlnsScope)
     {
         switch (token)
         {
             case JArray array:
                 foreach (var item in array.Children().ToList())
-                    CorrectTypes(item, actionOnBadValues, xmlnsScope);
+                    CorrectTypes(item, actionOnBadValues, mode, xmlnsScope);
                 break;
 
             case JObject obj:
                 var childScope = ExtendXmlnsScope(obj, xmlnsScope);
                 foreach (var value in obj.PropertyValues().ToList())
-                    CorrectTypes(value, actionOnBadValues, childScope);
+                    CorrectTypes(value, actionOnBadValues, mode, childScope);
+
+                // xsi:nil handling runs first so it can collapse the wrapper to a default/null
+                // (or strip the attribute so ApplyTypeHint sees a clean element).
+                if (ApplyXsiNil(obj, mode, childScope))
+                    break;
+
                 ApplyTypeHint(obj, actionOnBadValues, childScope);
                 break;
         }
@@ -325,13 +338,22 @@ public class JSON
             textProperty.Value = converted;
     }
 
+    private static JProperty FindXsiTypeProperty(JObject obj, IReadOnlyDictionary<string, string> xmlnsScope) =>
+        FindXsiNamespacedAttribute(obj, "type", xmlnsScope);
+
+    private static JProperty FindXsiNilProperty(JObject obj, IReadOnlyDictionary<string, string> xmlnsScope) =>
+        FindXsiNamespacedAttribute(obj, "nil", xmlnsScope);
+
     /// <summary>
-    /// Finds the first attribute on this JObject named "@&lt;prefix&gt;:type" where &lt;prefix&gt; is
-    /// bound (in the active xmlns scope) to the XML Schema Instance namespace. Newtonsoft
-    /// preserves the source prefix, so authors using xmlns:i (instead of the conventional xsi)
-    /// still get their type hints honoured.
+    /// Finds the first attribute on this JObject named "@&lt;prefix&gt;:&lt;localName&gt;" where
+    /// &lt;prefix&gt; is bound (in the active xmlns scope) to the XML Schema Instance namespace.
+    /// Newtonsoft preserves the source prefix, so authors using xmlns:i (instead of the
+    /// conventional xsi) still get their type/nil hints honoured.
     /// </summary>
-    private static JProperty FindXsiTypeProperty(JObject obj, IReadOnlyDictionary<string, string> xmlnsScope)
+    private static JProperty FindXsiNamespacedAttribute(
+        JObject obj,
+        string localName,
+        IReadOnlyDictionary<string, string> xmlnsScope)
     {
         foreach (var prop in obj.Properties())
         {
@@ -343,7 +365,7 @@ public class JSON
                 continue;
 
             var local = prop.Name.Substring(colonIndex + 1);
-            if (!string.Equals(local, "type", StringComparison.Ordinal))
+            if (!string.Equals(local, localName, StringComparison.Ordinal))
                 continue;
 
             var prefix = prop.Name.Substring(1, colonIndex - 1);
@@ -353,6 +375,168 @@ public class JSON
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Applies xsi:nil semantics. Returns true when the JObject was replaced/finalised and no
+    /// further type-hint processing is needed on it.
+    /// <para>nil="true" empty → JSON null (replacing the wrapper).
+    /// nil="true" with content → strip the attribute, let content flow through.
+    /// nil="false" empty → coerce to default(T) (T from xsi:type, or "" when Schema mode
+    /// validated the element without providing a convertible type; Attributes mode without
+    /// xsi:type is left alone).
+    /// nil="false" with content → strip the attribute, let content flow through.</para>
+    /// </summary>
+    private static bool ApplyXsiNil(
+        JObject obj,
+        TypeCorrectionMode mode,
+        IReadOnlyDictionary<string, string> xmlnsScope)
+    {
+        var nilProperty = FindXsiNilProperty(obj, xmlnsScope);
+        if (nilProperty == null)
+            return false;
+
+        var nilFlag = ParseNilFlag(nilProperty.Value.ToString());
+        if (nilFlag == null)
+            return false;
+
+        var textProperty = obj.Property(TextPropertyName, StringComparison.Ordinal);
+        if (HasContent(obj, textProperty))
+        {
+            // Content wins — drop the nil attribute. If the wrapper now has nothing else
+            // meaningful to carry (no xsi:type for further conversion, no other attributes),
+            // collapse it to the bare text value so the shape matches an authored element
+            // that never had xsi:nil.
+            nilProperty.Remove();
+
+            var typeProperty = FindXsiTypeProperty(obj, xmlnsScope);
+            if (typeProperty == null && textProperty != null &&
+                obj.Parent != null && OnlyTextOrNamespaceDeclarations(obj))
+            {
+                obj.Replace(textProperty.Value);
+                return true;
+            }
+
+            return false;
+        }
+
+        // Empty element — handle the nil flag.
+        if (nilFlag == true)
+        {
+            nilProperty.Remove();
+            ReplaceOrClearWrapper(obj, textProperty, JValue.CreateNull());
+            return true;
+        }
+
+        // nil = false on an empty element: coerce to default(T), but only when we actually
+        // have type info to derive T from.
+        var typePropertyForDefault = FindXsiTypeProperty(obj, xmlnsScope);
+        JValue defaultValue;
+
+        if (typePropertyForDefault != null)
+        {
+            defaultValue = DefaultValueForTypeName(LocalName(typePropertyForDefault.Value.ToString()));
+            typePropertyForDefault.Remove();
+        }
+        else if (mode == TypeCorrectionMode.Schema)
+        {
+            // The schema validated this element; a missing xsi:type means the schema's type is
+            // a non-convertible one (xs:string or similar). Default to an empty string.
+            defaultValue = new JValue(string.Empty);
+        }
+        else
+        {
+            // Attributes mode with no inline xsi:type: per design, only act when type info is
+            // present. Leave xsi:nil in place so the caller can still see the marker.
+            return false;
+        }
+
+        nilProperty.Remove();
+        ReplaceOrClearWrapper(obj, textProperty, defaultValue);
+        return true;
+    }
+
+    private static bool OnlyTextOrNamespaceDeclarations(JObject obj)
+    {
+        foreach (var prop in obj.Properties())
+        {
+            if (prop.Name == TextPropertyName)
+                continue;
+            if (prop.Name.StartsWith("@xmlns", StringComparison.Ordinal))
+                continue;
+            return false;
+        }
+        return true;
+    }
+
+    private static bool? ParseNilFlag(string value)
+    {
+        var trimmed = value?.Trim() ?? string.Empty;
+
+        if (trimmed == "1" || string.Equals(trimmed, "true", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        if (trimmed == "0" || string.Equals(trimmed, "false", StringComparison.OrdinalIgnoreCase))
+            return false;
+
+        return null;
+    }
+
+    private static bool HasContent(JObject obj, JProperty textProperty)
+    {
+        if (textProperty != null && textProperty.Value.Type == JTokenType.String &&
+            !string.IsNullOrEmpty(textProperty.Value.ToString()))
+            return true;
+
+        foreach (var prop in obj.Properties())
+        {
+            if (prop.Name.Length == 0 || prop.Name[0] == '@' || prop.Name == TextPropertyName)
+                continue;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// When the wrapper's only remaining properties are namespace declarations, collapse it to
+    /// the new scalar value. Otherwise preserve the wrapper (other attributes are still
+    /// meaningful) and assign the value to #text.
+    /// </summary>
+    private static void ReplaceOrClearWrapper(JObject obj, JProperty existingTextProperty, JValue newValue)
+    {
+        var canCollapse = obj.Parent != null &&
+            obj.Properties().All(p => p.Name.StartsWith("@xmlns", StringComparison.Ordinal));
+
+        if (canCollapse)
+        {
+            obj.Replace(newValue);
+            return;
+        }
+
+        if (existingTextProperty != null)
+            existingTextProperty.Value = newValue;
+        else
+            obj[TextPropertyName] = newValue;
+    }
+
+    /// <summary>
+    /// Mirrors C# default(T) for the recognized XSD-ish type names; unknown types fall back to
+    /// an empty string so callers always get a usable JSON value.
+    /// </summary>
+    private static JValue DefaultValueForTypeName(string typeName)
+    {
+        if (string.IsNullOrEmpty(typeName) || !TypeConverters.ContainsKey(typeName))
+            return new JValue(string.Empty);
+
+        return typeName.ToLowerInvariant() switch
+        {
+            "float" or "double" => new JValue(0d),
+            "decimal" => new JValue(0m),
+            "boolean" => new JValue(false),
+            _ => new JValue(0L),
+        };
     }
 
     private static bool IsXsiNamespaceDeclaration(JProperty property)

--- a/Frends.JSON.ConvertXMLStringToJToken/Frends.JSON.ConvertXMLStringToJToken/ConvertXMLStringToJToken.cs
+++ b/Frends.JSON.ConvertXMLStringToJToken/Frends.JSON.ConvertXMLStringToJToken/ConvertXMLStringToJToken.cs
@@ -23,7 +23,10 @@ public class JSON
     private const string XsiNamespace = "http://www.w3.org/2001/XMLSchema-instance";
 
     private const string TextPropertyName = "#text";
-    private const string XsiTypePropertyName = "@xsi:type";
+    private const string XmlnsPrefixSeparator = "@xmlns:";
+
+    private static readonly IReadOnlyDictionary<string, string> EmptyXmlnsScope =
+        new Dictionary<string, string>(0, StringComparer.Ordinal);
 
     /// <summary>
     /// Maps an XSD type local name to a parser producing a native JSON value, or null when unparseable.
@@ -73,7 +76,10 @@ public class JSON
         var jsonString = JsonConvert.SerializeXmlNode(doc);
         var token = JToken.Parse(jsonString);
 
-        if (options.TypeCorrection != TypeCorrectionMode.None)
+        // Attributes always runs; Schema mode only runs when it has an XSD to derive types from,
+        // so picking Schema with a blank XSD stays a true no-op even if the input XML happens to
+        // carry inline xsi:type attributes.
+        if (options.TypeCorrection == TypeCorrectionMode.Attributes || useSchema)
             CorrectTypes(token, options.ActionOnBadValues);
 
         return new Result(true, token);
@@ -91,6 +97,12 @@ public class JSON
         var schemaSet = CreateSchemaSet(xsd);
 
         var xDocument = XDocument.Parse(xml);
+
+        // In Schema mode the XSD is the single source of truth; pull any author-written
+        // xsi:type off the document up front so it can't trip the validator (an unqualified
+        // xsi:type='int' is otherwise rejected before we ever get to AddSchemaHints) or shadow
+        // a schema-derived hint.
+        RemoveInlineXsiTypeAttributes(xDocument);
 
         xDocument.Validate(
             schemaSet,
@@ -110,6 +122,22 @@ public class JSON
         xmlDocument.Load(reader);
 
         return xmlDocument;
+    }
+
+    /// <summary>
+    /// Removes any xsi:type attribute (under any prefix bound to the XML Schema Instance
+    /// namespace) from every element in the document.
+    /// </summary>
+    private static void RemoveInlineXsiTypeAttributes(XDocument document)
+    {
+        if (document.Root == null)
+            return;
+
+        XNamespace xsiNs = XsiNamespace;
+        var xsiType = xsiNs + "type";
+
+        foreach (var element in document.Root.DescendantsAndSelf())
+            element.Attribute(xsiType)?.Remove();
     }
 
     private static XmlSchemaSet CreateSchemaSet(string xsd)
@@ -208,24 +236,60 @@ public class JSON
     /// </summary>
     private static void CorrectTypes(JToken token, BadValueAction actionOnBadValues)
     {
+        CorrectTypes(token, actionOnBadValues, EmptyXmlnsScope);
+    }
+
+    private static void CorrectTypes(
+        JToken token,
+        BadValueAction actionOnBadValues,
+        IReadOnlyDictionary<string, string> xmlnsScope)
+    {
         switch (token)
         {
             case JArray array:
                 foreach (var item in array.Children().ToList())
-                    CorrectTypes(item, actionOnBadValues);
+                    CorrectTypes(item, actionOnBadValues, xmlnsScope);
                 break;
 
             case JObject obj:
+                var childScope = ExtendXmlnsScope(obj, xmlnsScope);
                 foreach (var value in obj.PropertyValues().ToList())
-                    CorrectTypes(value, actionOnBadValues);
-                ApplyTypeHint(obj, actionOnBadValues);
+                    CorrectTypes(value, actionOnBadValues, childScope);
+                ApplyTypeHint(obj, actionOnBadValues, childScope);
                 break;
         }
     }
 
-    private static void ApplyTypeHint(JObject obj, BadValueAction actionOnBadValues)
+    /// <summary>
+    /// Extends an xmlns prefix-to-namespace map with any @xmlns:* declarations carried on this
+    /// JObject, so that nested elements can resolve type-hint prefixes (e.g. xmlns:i bound here,
+    /// i:type used on a descendant). Inner declarations shadow outer ones, matching XML scope.
+    /// </summary>
+    private static IReadOnlyDictionary<string, string> ExtendXmlnsScope(
+        JObject obj,
+        IReadOnlyDictionary<string, string> parentScope)
     {
-        var typeProperty = obj.Property(XsiTypePropertyName, StringComparison.Ordinal);
+        Dictionary<string, string> extended = null;
+
+        foreach (var prop in obj.Properties())
+        {
+            if (!prop.Name.StartsWith(XmlnsPrefixSeparator, StringComparison.Ordinal))
+                continue;
+
+            extended ??= new Dictionary<string, string>(parentScope, StringComparer.Ordinal);
+            var prefix = prop.Name.Substring(XmlnsPrefixSeparator.Length);
+            extended[prefix] = prop.Value.ToString();
+        }
+
+        return extended ?? parentScope;
+    }
+
+    private static void ApplyTypeHint(
+        JObject obj,
+        BadValueAction actionOnBadValues,
+        IReadOnlyDictionary<string, string> xmlnsScope)
+    {
+        var typeProperty = FindXsiTypeProperty(obj, xmlnsScope);
         if (typeProperty == null)
             return;
 
@@ -259,6 +323,36 @@ public class JSON
             obj.Replace(converted);
         else
             textProperty.Value = converted;
+    }
+
+    /// <summary>
+    /// Finds the first attribute on this JObject named "@&lt;prefix&gt;:type" where &lt;prefix&gt; is
+    /// bound (in the active xmlns scope) to the XML Schema Instance namespace. Newtonsoft
+    /// preserves the source prefix, so authors using xmlns:i (instead of the conventional xsi)
+    /// still get their type hints honoured.
+    /// </summary>
+    private static JProperty FindXsiTypeProperty(JObject obj, IReadOnlyDictionary<string, string> xmlnsScope)
+    {
+        foreach (var prop in obj.Properties())
+        {
+            if (prop.Name.Length < 2 || prop.Name[0] != '@')
+                continue;
+
+            var colonIndex = prop.Name.IndexOf(':');
+            if (colonIndex < 0)
+                continue;
+
+            var local = prop.Name.Substring(colonIndex + 1);
+            if (!string.Equals(local, "type", StringComparison.Ordinal))
+                continue;
+
+            var prefix = prop.Name.Substring(1, colonIndex - 1);
+            if (xmlnsScope.TryGetValue(prefix, out var ns) &&
+                string.Equals(ns, XsiNamespace, StringComparison.Ordinal))
+                return prop;
+        }
+
+        return null;
     }
 
     private static bool IsXsiNamespaceDeclaration(JProperty property)
@@ -306,16 +400,14 @@ public class JSON
 
     private static JValue ParseBoolean(string value)
     {
-        switch (value.Trim())
-        {
-            case "true":
-            case "1":
-                return new JValue(true);
-            case "false":
-            case "0":
-                return new JValue(false);
-            default:
-                return null;
-        }
+        var trimmed = value.Trim();
+
+        if (trimmed == "1" || string.Equals(trimmed, "true", StringComparison.OrdinalIgnoreCase))
+            return new JValue(true);
+
+        if (trimmed == "0" || string.Equals(trimmed, "false", StringComparison.OrdinalIgnoreCase))
+            return new JValue(false);
+
+        return null;
     }
 }

--- a/Frends.JSON.ConvertXMLStringToJToken/Frends.JSON.ConvertXMLStringToJToken/Definitions/Input.cs
+++ b/Frends.JSON.ConvertXMLStringToJToken/Frends.JSON.ConvertXMLStringToJToken/Definitions/Input.cs
@@ -10,13 +10,4 @@ public class Input
     /// </summary>
     /// <example>&lt;?xml version='1.0' standalone='no'?&gt;&lt;root&gt;&lt;foos id = '1' &gt;&lt;foo&gt;bar&lt;/name&gt;&lt;/foos&gt;&lt;/root&gt;</example>
     public string XML { get; set; }
-
-    /// <summary>
-    /// Optional XSD schema used for XML validation and for determining
-    /// whether XML elements should be serialized as JSON arrays.
-    /// </summary>
-    /// <example>
-    /// &lt;xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema'&gt;...&lt;/xs:schema&gt;
-    /// </example>
-    public string XSD { get; set; }
 }

--- a/Frends.JSON.ConvertXMLStringToJToken/Frends.JSON.ConvertXMLStringToJToken/Definitions/Options.cs
+++ b/Frends.JSON.ConvertXMLStringToJToken/Frends.JSON.ConvertXMLStringToJToken/Definitions/Options.cs
@@ -1,0 +1,52 @@
+using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+
+namespace Frends.JSON.ConvertXMLStringToJToken.Definitions;
+
+/// <summary>
+/// Controls how XML values are mapped to native JSON types.
+/// </summary>
+public enum TypeCorrectionMode
+{
+    /// <summary>
+    /// No type correction. Every value is emitted as a JSON string (default, backwards compatible).
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// Read inline xsi:type attributes from the XML (e.g. xsi:type="float") to convert
+    /// numeric and boolean values into native JSON types.
+    /// </summary>
+    Attributes,
+
+    /// <summary>
+    /// Derive value types from the provided XSD schema (xs:float, xs:int, xs:boolean, ...)
+    /// to convert numeric and boolean values into native JSON types. Requires an XSD.
+    /// </summary>
+    Schema,
+}
+
+/// <summary>
+/// Optional parameters.
+/// </summary>
+public class Options
+{
+    /// <summary>
+    /// Whether and how to convert string values into native JSON numbers and booleans.
+    /// None leaves all values as strings (default). Attributes reads inline xsi:type hints
+    /// from the XML. Schema derives the types from the supplied XSD.
+    /// </summary>
+    /// <example>TypeCorrectionMode.Attributes</example>
+    [DefaultValue(TypeCorrectionMode.None)]
+    public TypeCorrectionMode TypeCorrection { get; set; } = TypeCorrectionMode.None;
+
+    /// <summary>
+    /// XSD schema used to validate the XML and to derive value types and array mapping.
+    /// Only used (and shown) when TypeCorrection is Schema.
+    /// </summary>
+    /// <example>
+    /// &lt;xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema'&gt;...&lt;/xs:schema&gt;
+    /// </example>
+    [UIHint(nameof(TypeCorrection), "", TypeCorrectionMode.Schema)]
+    public string XSD { get; set; }
+}

--- a/Frends.JSON.ConvertXMLStringToJToken/Frends.JSON.ConvertXMLStringToJToken/Definitions/Options.cs
+++ b/Frends.JSON.ConvertXMLStringToJToken/Frends.JSON.ConvertXMLStringToJToken/Definitions/Options.cs
@@ -27,6 +27,23 @@ public enum TypeCorrectionMode
 }
 
 /// <summary>
+/// Controls what happens when a value carries a known numeric/boolean type hint but cannot
+/// be parsed as that type (e.g. xsi:type="int" with value "abc").
+/// </summary>
+public enum BadValueAction
+{
+    /// <summary>
+    /// Leave the unparseable value as a JSON string (default, backwards compatible).
+    /// </summary>
+    Ignore,
+
+    /// <summary>
+    /// Throw an exception identifying the element and value that failed to convert.
+    /// </summary>
+    Throw,
+}
+
+/// <summary>
 /// Optional parameters.
 /// </summary>
 public class Options
@@ -49,4 +66,15 @@ public class Options
     /// </example>
     [UIHint(nameof(TypeCorrection), "", TypeCorrectionMode.Schema)]
     public string XSD { get; set; }
+
+    /// <summary>
+    /// What to do when a value carries a recognized numeric/boolean type hint but cannot be
+    /// parsed as that type (e.g. xsi:type="int" with value "abc"). Ignore (default) keeps the
+    /// unparseable value as a JSON string. Throw raises an exception identifying the element
+    /// and value. Only used (and shown) when TypeCorrection is Attributes or Schema.
+    /// </summary>
+    /// <example>BadValueAction.Throw</example>
+    [DefaultValue(BadValueAction.Ignore)]
+    [UIHint(nameof(TypeCorrection), "", TypeCorrectionMode.Attributes, TypeCorrectionMode.Schema)]
+    public BadValueAction ActionOnBadValues { get; set; } = BadValueAction.Ignore;
 }

--- a/Frends.JSON.ConvertXMLStringToJToken/Frends.JSON.ConvertXMLStringToJToken/Frends.JSON.ConvertXMLStringToJToken.csproj
+++ b/Frends.JSON.ConvertXMLStringToJToken/Frends.JSON.ConvertXMLStringToJToken/Frends.JSON.ConvertXMLStringToJToken.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 	<TargetFrameworks>net6.0</TargetFrameworks>
-	<Version>1.2.0</Version>
+	<Version>2.0.0</Version>
 	<Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>
@@ -19,6 +19,8 @@
 	  <None Include="FrendsTaskMetadata.json" Pack="true" PackagePath="/">
 		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 	  </None>
+	  <Content Include="migration.json" PackagePath="/" Pack="true" />
+	  <Content Include="../CHANGELOG.md" PackagePath="/" Pack="true" />
   </ItemGroup>
 	
   <ItemGroup>

--- a/Frends.JSON.ConvertXMLStringToJToken/Frends.JSON.ConvertXMLStringToJToken/migration.json
+++ b/Frends.JSON.ConvertXMLStringToJToken/Frends.JSON.ConvertXMLStringToJToken/migration.json
@@ -1,0 +1,23 @@
+[
+    {
+        "Task": "Frends.JSON.ConvertXMLStringToJToken.JSON.ConvertXMLStringToJToken",
+        "Migrations": [
+            {
+                "Version": "2.0.0",
+                "Description": "Moved the XSD parameter from the Input tab to the Options tab.",
+                "Migration": [
+                    {
+                        "Type": "Copy",
+                        "Source": "Input.XSD",
+                        "Target": "Options.XSD"
+                    },
+                    {
+                        "Type": "Set",
+                        "Target": "Options.TypeCorrection",
+                        "Value": "Schema"
+                    }
+                ]
+            }
+        ]
+    }
+]


### PR DESCRIPTION
## Summary
Adds an `Options` parameter with `TypeCorrection` (`None` / `Attributes` / `Schema`) so the task can emit native JSON numbers and booleans instead of stringifying everything.

- **`Attributes`** — reads inline `xsi:type` hints from the XML (e.g. `xsi:type="float"`).
- **`Schema`** — derives value types (and array mapping) from the supplied XSD.
- **`None`** (default) — unchanged behavior; every value stays a string.

Full numeric + boolean set is supported (`float`/`double`/`decimal`, the integer family, `boolean`); unparseable values are left as strings.

## ⚠️ Breaking change (2.0.0)
The `XSD` parameter moved from the **Input** tab to the **Options** tab and is only used/shown in `Schema` mode.

- `migration.json` ships with the package: copies `Input.XSD` → `Options.XSD` and sets `TypeCorrection = Schema`, preserving the 1.2.0 array-mapping behavior.
- **Tenants that don't apply migration.json must upgrade manually:** on each affected step set Options `TypeCorrection = Schema` and paste the XSD into `Options.XSD`. Steps that never used an XSD need no change.
- `Schema` mode with a blank XSD is a graceful no-op (returns strings) rather than an error, which keeps the unconditional migration safe.

See `CHANGELOG.md` for the full rationale and upgrade path.

## Changes
- New `Definitions/Options.cs` (`Options` + `TypeCorrectionMode`); `XSD` carries `[UIHint(nameof(TypeCorrection), "", TypeCorrectionMode.Schema)]` for conditional display.
- `XSD` removed from `Definitions/Input.cs`.
- Type-correction + schema type-injection logic in `ConvertXMLStringToJToken.cs`.
- `migration.json` + `CHANGELOG.md` wired into csproj packaging; version → `2.0.0`.

## Testing
`dotnet test` — 9/9 passing (None/Attributes/Schema modes, keep-wrapper, unparseable fallback, schema-typed arrays, no-op-without-xsd). Also verified the real hotels XML+XSD converts `star_rating`→Integer and `open_for_booking`→Boolean via a throwaway harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TypeCorrection modes (None / Attributes / Schema) to convert XML numeric/boolean values to native JSON; Schema mode also drives array mapping.
  * XSD input moved into Options and is applied only when TypeCorrection = Schema.

* **Tests**
  * Expanded unit tests for TypeCorrection modes, xsi:nil handling, and bad-value behaviors.

* **Documentation**
  * Changelog updated with 2.0.0 notes and migration guidance (automated migration provided; manual upgrade steps documented).

* **Chores**
  * Package version bumped to 2.0.0; migration configuration included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->