### PR TITLE
Copilot/fix error handling no matches

### DIFF
--- a/Frends.JSON.Query/CHANGELOG.md
+++ b/Frends.JSON.Query/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.2.0] - 2026-07-08
+### Fixed
+- Fixed issue where Options.ErrorWhenNotMatched did not throw an exception when a JSONPath filter expression (e.g. `[?(...)]`) matched no results.
+
 ## [1.1.0] - 2024-08-20
 ### Updated
 - Updated Newtonsoft.Json library to the latest version 13.0.3.

--- a/Frends.JSON.Query/Frends.JSON.Query.UnitTests/UnitTests.cs
+++ b/Frends.JSON.Query/Frends.JSON.Query.UnitTests/UnitTests.cs
@@ -1,5 +1,6 @@
 using Frends.JSON.Query.Definitions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Frends.JSON.Query.UnitTests;
@@ -77,6 +78,23 @@ public class UnitTests
         Assert.IsTrue(result.Success);
         Assert.AreEqual(2, result.Data.Count());
         Assert.AreEqual("Anvil", result.Data.First().ToString());
+    }
+
+    [TestMethod]
+    public void QueryShouldThrowIfOptionSetAndFilterMatchesNothing()
+    {
+        var input = new Input()
+        {
+            Json = jsonString,
+            Query = "$..Products[?(@.Price >= 1000)].Name"
+        };
+
+        var options = new Options()
+        {
+            ErrorWhenNotMatched = true,
+        };
+
+        Assert.ThrowsException<JsonException>(() => JSON.Query(input, options));
     }
 
     [TestMethod]

--- a/Frends.JSON.Query/Frends.JSON.Query/Frends.JSON.Query.csproj
+++ b/Frends.JSON.Query/Frends.JSON.Query/Frends.JSON.Query.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 	<TargetFrameworks>net6.0</TargetFrameworks>
-	<Version>1.1.0</Version>
+	<Version>1.2.0</Version>
 	<Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>

--- a/Frends.JSON.Query/Frends.JSON.Query/Query.cs
+++ b/Frends.JSON.Query/Frends.JSON.Query/Query.cs
@@ -1,7 +1,9 @@
 ﻿using Frends.JSON.Query.Definitions;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System.ComponentModel;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.Loader;
 
@@ -31,7 +33,12 @@ public class JSON
     public static Result Query([PropertyTab] Input input, [PropertyTab] Options options)
     {
         JToken jToken = GetJTokenFromInput(input.Json);
-        return new Result(true, jToken.SelectTokens(input.Query, options.ErrorWhenNotMatched));
+        var tokens = jToken.SelectTokens(input.Query, options.ErrorWhenNotMatched).ToList();
+
+        if (tokens.Count == 0 && options.ErrorWhenNotMatched)
+            throw new JsonException($"No matches found for query '{input.Query}'.");
+
+        return new Result(true, tokens);
     }
 
     private static object GetJTokenFromInput(dynamic json)

--- a/Frends.JSON.QuerySingle/CHANGELOG.md
+++ b/Frends.JSON.QuerySingle/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.3.0] - 2026-07-08
+### Fixed
+- Fixed issue where Options.ErrorWhenNotMatched did not throw an exception when a JSONPath filter expression (e.g. `[?(...)]`) matched no results.
+
 ## [1.2.0] - 2024-11-07
 ### Fixed
 - Fixed issue with result dotnotation by changing the result Data object type to dynamic.

--- a/Frends.JSON.QuerySingle/Frends.JSON.QuerySingle.UnitTests/UnitTests.cs
+++ b/Frends.JSON.QuerySingle/Frends.JSON.QuerySingle.UnitTests/UnitTests.cs
@@ -78,6 +78,23 @@ public class UnitTests
     }
 
     [TestMethod]
+    public void QuerySingleShouldThrowIfOptionSetAndFilterMatchesNothing()
+    {
+        var input = new Input()
+        {
+            Json = jsonString,
+            Query = "$.Manufacturers[?(@.Name == 'Nonexistent Co')]"
+        };
+
+        var options = new Options()
+        {
+            ErrorWhenNotMatched = true,
+        };
+
+        Assert.ThrowsException<JsonException>(() => JSON.QuerySingle(input, options));
+    }
+
+    [TestMethod]
     public void QuerySingleShouldNotThrowIfOptionNotSetAndNothingIsFound()
     {
         var input = new Input()

--- a/Frends.JSON.QuerySingle/Frends.JSON.QuerySingle/Frends.JSON.QuerySingle.csproj
+++ b/Frends.JSON.QuerySingle/Frends.JSON.QuerySingle/Frends.JSON.QuerySingle.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 	<TargetFrameworks>net6.0</TargetFrameworks>
-	<Version>1.2.0</Version>
+	<Version>1.3.0</Version>
 	<Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>

--- a/Frends.JSON.QuerySingle/Frends.JSON.QuerySingle/QuerySingle.cs
+++ b/Frends.JSON.QuerySingle/Frends.JSON.QuerySingle/QuerySingle.cs
@@ -1,4 +1,5 @@
 ﻿using Frends.JSON.QuerySingle.Definitions;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System.ComponentModel;
 using System.IO;
@@ -31,7 +32,12 @@ public class JSON
     public static Result QuerySingle([PropertyTab] Input input, [PropertyTab] Options options)
     {
         JToken jToken = GetJTokenFromInput(input.Json);
-        return new Result(true, jToken.SelectToken(input.Query, options.ErrorWhenNotMatched));
+        JToken result = jToken.SelectToken(input.Query, options.ErrorWhenNotMatched);
+
+        if (result == null && options.ErrorWhenNotMatched)
+            throw new JsonException($"No matches found for query '{input.Query}'.");
+
+        return new Result(true, result);
     }
 
     private static object GetJTokenFromInput(dynamic json)


### PR DESCRIPTION
## Dear PR creator, please select one of the PR templates, then remove others and this text.

---

# *Default PR template*

Please review my changes :)

---

# *Task Update PR template*

## Review Checklist

- [ ] Task version updated (x.x.0)
- [ ] CHANGELOG.md updated
- [ ] Solution builds
- [ ] Warnings resolved (if possible)
- [ ] Typos resolved
- [ ] Tests cover new code
- [ ] Description how to run tests locally added to README.md (if needed)
- [ ] All tests pass locally

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `Query` and `QuerySingle` now throw an exception when **ErrorWhenNotMatched** is enabled and no JSONPath results are found.
  * This makes failed matches easier to detect instead of returning an empty or null result.
* **Tests**
  * Added coverage for the no-match exception behavior in both query operations.
* **Chores**
  * Updated package versions and changelog entries for the new release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->